### PR TITLE
Add soul link websocket client and multi-game exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,18 @@
 # Soul Link Tracker
 
-This repository contains simple utilities for reading Pokémon party data from DeSmuME.
+This repository contains utilities for reading Pokémon party data from
+DeSmuME and sharing it with a partner.
 
-* `team_export.lua` – Exports the player\'s party information from Pokémon Diamond/Pearl every two seconds. The data is written to `team_data.json`.
+* `team_export.lua` – Lua script that exports the player's party information
+  from a running game every two seconds. When started, the script asks which
+  game you are playing (Diamond/Pearl, HeartGold/SoulSilver, Black/White, or
+  Black2/White2) and uses the appropriate memory offsets. The data is written to
+  `team_data.json`.
 
-Run the script through DeSmuME\'s Lua scripting interface while playing the game.
+* `soul_link.py` – Python script that reads `team_data.json`, connects to a
+  WebSocket server, and exchanges team information with your partner. It prints
+  both teams to the terminal, applies the soul link fainting rule, and logs
+  updates to `soul_link_log.json`.
+
+Run `team_export.lua` through DeSmuME's Lua scripting interface and execute
+`soul_link.py` while playing to sync your party with your partner.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+websockets>=11.0

--- a/soul_link.py
+++ b/soul_link.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Real-time Soul Link tracker using websockets."""
+
+import asyncio
+import json
+import os
+import time
+from typing import List, Dict
+
+import websockets
+
+TEAM_FILE = "team_data.json"
+LOG_FILE = "soul_link_log.json"
+
+
+def read_team() -> List[Dict]:
+    """Read team data from TEAM_FILE."""
+    if not os.path.exists(TEAM_FILE):
+        return []
+    try:
+        with open(TEAM_FILE, "r") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return []
+
+
+def print_team(team: List[Dict], title: str) -> None:
+    print(f"== {title} ==")
+    if not team:
+        print("(no data)")
+        return
+    for idx, mon in enumerate(team, start=1):
+        species = mon.get("species")
+        level = mon.get("level")
+        hp = mon.get("hp")
+        max_hp = mon.get("max_hp")
+        fainted = mon.get("fainted")
+        print(f"{idx}. species={species} level={level} hp={hp}/{max_hp} fainted={fainted}")
+
+
+def apply_soul_link(our_team: List[Dict], other_team: List[Dict]) -> None:
+    """If a Pokémon in our team is fainted, mark the corresponding one in the
+    other team as fainted as well."""
+    for i, mon in enumerate(our_team):
+        if mon.get("fainted") and i < len(other_team):
+            other_team[i]["fainted"] = True
+
+
+def append_log(history: List[Dict], our_team: List[Dict], other_team: List[Dict]) -> None:
+    history.append({
+        "timestamp": time.time(),
+        "our_team": our_team,
+        "partner_team": other_team,
+    })
+    with open(LOG_FILE, "w") as f:
+        json.dump(history, f, indent=2)
+
+
+async def run_soul_link(uri: str) -> None:
+    history: List[Dict] = []
+    async with websockets.connect(uri) as ws:
+        other_team: List[Dict] = []
+        while True:
+            our_team = read_team()
+            await ws.send(json.dumps(our_team))
+            try:
+                msg = await asyncio.wait_for(ws.recv(), timeout=1)
+                other_team = json.loads(msg)
+            except asyncio.TimeoutError:
+                # no update from partner
+                pass
+            apply_soul_link(our_team, other_team)
+            os.system("clear")
+            print_team(our_team, "Your Team")
+            print()
+            print_team(other_team, "Partner Team")
+            append_log(history, our_team, other_team)
+            await asyncio.sleep(2)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Soul Link WebSocket client")
+    parser.add_argument("url", help="WebSocket server URL, e.g. ws://localhost:8765")
+    args = parser.parse_args()
+
+    try:
+        asyncio.run(run_soul_link(args.url))
+    except KeyboardInterrupt:
+        print("Exiting...")

--- a/team_export.lua
+++ b/team_export.lua
@@ -1,15 +1,64 @@
--- DeSmuME Lua script to export party data every 2 seconds
--- Memory offsets for Pokemon Diamond/Pearl (U)
+-- Configuration for various games. The addresses are examples and may need to
+-- be adjusted for your ROM version.
+local GAME_CONFIGS = {
+    ["Diamond/Pearl"] = {
+        PARTY_START = 0x02101D2C,
+        POKEMON_SIZE = 0xEC,
+        SPECIES_OFFSET = 0x08,
+        LEVEL_OFFSET = 0x84,
+        HP_OFFSET = 0x86,
+        MAX_HP_OFFSET = 0x88
+    },
+    ["HeartGold/SoulSilver"] = {
+        PARTY_START = 0x02111870,
+        POKEMON_SIZE = 0xEC,
+        SPECIES_OFFSET = 0x08,
+        LEVEL_OFFSET = 0x84,
+        HP_OFFSET = 0x86,
+        MAX_HP_OFFSET = 0x88
+    },
+    ["Black/White"] = {
+        PARTY_START = 0x02257C20,
+        POKEMON_SIZE = 0x1EC,
+        SPECIES_OFFSET = 0x08,
+        LEVEL_OFFSET = 0x84,
+        HP_OFFSET = 0x86,
+        MAX_HP_OFFSET = 0x88
+    },
+    ["Black2/White2"] = {
+        PARTY_START = 0x02256A20,
+        POKEMON_SIZE = 0x1EC,
+        SPECIES_OFFSET = 0x08,
+        LEVEL_OFFSET = 0x84,
+        HP_OFFSET = 0x86,
+        MAX_HP_OFFSET = 0x88
+    }
+}
 
-local PARTY_START = 0x02101D2C   -- start address of player's party data
-local POKEMON_SIZE = 0xEC        -- size of one Pokemon data structure
-local NUM_SLOTS = 6              -- maximum party size
+local NUM_SLOTS = 6 -- maximum party size
+
+-- Ask the user which game is running
+print("Select your game:")
+local game_list = {}
+for name, _ in pairs(GAME_CONFIGS) do
+    game_list[#game_list + 1] = name
+end
+table.sort(game_list)
+for i, name in ipairs(game_list) do
+    print(string.format("%d) %s", i, name))
+end
+io.write("> ")
+local choice = tonumber(io.read()) or 1
+local selected = GAME_CONFIGS[game_list[choice]] or GAME_CONFIGS[game_list[1]]
+
+local PARTY_START = selected.PARTY_START
+local POKEMON_SIZE = selected.POKEMON_SIZE
 
 -- Offsets within each Pokemon structure
-local SPECIES_OFFSET = 0x08      -- 2 bytes
-local LEVEL_OFFSET = 0x84        -- 1 byte
-local HP_OFFSET = 0x86           -- 2 bytes (current HP)
-local MAX_HP_OFFSET = 0x88       -- 2 bytes (max HP)
+local SPECIES_OFFSET = selected.SPECIES_OFFSET
+local LEVEL_OFFSET = selected.LEVEL_OFFSET
+local HP_OFFSET = selected.HP_OFFSET
+local MAX_HP_OFFSET = selected.MAX_HP_OFFSET
 
 -- Simple JSON encoder
 local function json_encode(value)


### PR DESCRIPTION
## Summary
- update `team_export.lua` to select memory addresses for different DS games
- add `soul_link.py` that syncs team data over websockets and logs history
- update README with instructions for new scripts
- add requirements for websockets library

## Testing
- `python3 -m py_compile soul_link.py`

------
https://chatgpt.com/codex/tasks/task_e_688ac825960c83258d03b81029cd13f0