### PR TITLE
Add PyInstaller build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,16 @@ DeSmuME and sharing it with a partner.
 
 Run `team_export.lua` through DeSmuME's Lua scripting interface and execute
 `soul_link.py` while playing to sync your party with your partner.
+
+## Building a Windows executable
+
+To distribute the tracker as a standalone `.exe`, install [PyInstaller]
+(`pip install pyinstaller`) and run:
+
+```bash
+pyinstaller --onefile soul_link.py
+```
+
+The generated executable will be placed in the `dist/` folder as
+`soul_link.exe`. Players should still load `team_export.lua` in DeSmuME to
+select the game and export party data.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 websockets>=11.0
+pyinstaller


### PR DESCRIPTION
## Summary
- add README instructions for building a Windows executable using PyInstaller
- list `pyinstaller` in requirements

## Testing
- `python3 -m py_compile soul_link.py`
- ❌ `pip install pyinstaller` (failed due to network restrictions)

------
https://chatgpt.com/codex/tasks/task_e_688acad94b488325a15f53dc3af2a920