### PR TITLE
Handle extra return values from io.read in team_export

### DIFF
--- a/team_export.lua
+++ b/team_export.lua
@@ -48,7 +48,8 @@ for i, name in ipairs(game_list) do
     print(string.format("%d) %s", i, name))
 end
 io.write("> ")
-local choice = tonumber(io.read()) or 1
+local input = io.read()
+local choice = tonumber(input) or 1
 local selected = GAME_CONFIGS[game_list[choice]] or GAME_CONFIGS[game_list[1]]
 
 local PARTY_START = selected.PARTY_START


### PR DESCRIPTION
## Summary
- Fix user game selection crash by reading input into a variable before calling `tonumber`

## Testing
- `sudo apt-get update` *(fails: repository not signed)*
- `python -m py_compile soul_link.py`


------
https://chatgpt.com/codex/tasks/task_e_688cf53293288325b041cb394987c28f