### PR TITLE
Add Tkinter launcher for selecting game and starting DeSmuME

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This repository contains utilities for reading Pokémon party data from DeSmuME 
 
 * `team_export.lua` – Lua script that exports the player's party information from a running game every two seconds. When started, the script asks which game you are playing (Diamond/Pearl, HeartGold/SoulSilver, Black/White, or Black2/White2) and uses the appropriate memory offsets. The data is written to `team_data.json`.
 * `soul_link.py` – Python script that reads `team_data.json`, connects to a WebSocket server, and exchanges team information with your partner. It now opens a small window where you enter a five digit connection code and choose your game from a drop-down list including every DS title (Diamond, Pearl, Platinum, HeartGold, SoulSilver, Black, White, Black 2 and White 2). After starting, the console displays both teams, applies the soul link fainting rule, and logs updates to `soul_link_log.json`.
+* `launch_tracker.py` – Tkinter GUI that lets you select a DS game, writes the choice to `config.txt`, and launches DeSmuME with `team_export.lua`.
 
 Run `team_export.lua` through DeSmuME's Lua scripting interface and execute `soul_link.py` while playing to sync your party with your partner.
 

--- a/launch_tracker.py
+++ b/launch_tracker.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Simple GUI to select a Pokémon game and launch DeSmuME."""
+
+import os
+import subprocess
+import tkinter as tk
+from tkinter import ttk, messagebox
+
+GAMES = [
+    "Black/White",
+    "Black2/White2",
+    "Diamond/Pearl",
+    "HeartGold/SoulSilver",
+]
+
+
+def launch_tracker() -> None:
+    """Write game selection to config.txt and launch DeSmuME."""
+    game = game_var.get()
+    config_path = os.path.join(BASE_DIR, "config.txt")
+    try:
+        with open(config_path, "w", encoding="utf-8") as cfg:
+            cfg.write(game)
+    except OSError as exc:  # pragma: no cover - best effort
+        messagebox.showerror("Error", f"Failed to write config.txt: {exc}")
+        return
+
+    desmume = os.path.join(BASE_DIR, "desmume.exe")
+    lua_script = os.path.join(BASE_DIR, "team_export.lua")
+
+    try:
+        subprocess.Popen([desmume, f"--lua={lua_script}"], cwd=BASE_DIR)
+    except OSError as exc:
+        messagebox.showerror("Error", f"Failed to launch DeSmuME: {exc}")
+        return
+    root.destroy()
+
+
+if __name__ == "__main__":
+    BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+    root = tk.Tk()
+    root.title("Pokémon Game Selector")
+
+    ttk.Label(root, text="Select a Pokémon game:").pack(padx=10, pady=10)
+
+    game_var = tk.StringVar(value=GAMES[0])
+    ttk.Combobox(
+        root, textvariable=game_var, values=GAMES, state="readonly"
+    ).pack(padx=10, pady=10)
+
+    ttk.Button(root, text="Launch Tracker", command=launch_tracker).pack(
+        padx=10, pady=10
+    )
+
+    root.mainloop()


### PR DESCRIPTION
## Summary
- add Tkinter GUI to choose a DS game and start DeSmuME with `team_export.lua`
- document the new launcher script in README

## Testing
- `python -m py_compile launch_tracker.py`


------
https://chatgpt.com/codex/tasks/task_e_688cfd9d38848325846d306accb98395