### PR TITLE
Improve launch tracker UI and ROM selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains utilities for reading Pokémon party data from DeSmuME 
 
 * `team_export.lua` – Lua script that exports the player's party information from a running game every two seconds. When started, the script asks which game you are playing (Diamond/Pearl, HeartGold/SoulSilver, Black/White, or Black2/White2) and uses the appropriate memory offsets. The data is written to `team_data.json`.
 * `soul_link.py` – Python script that reads `team_data.json`, connects to a WebSocket server, and exchanges team information with your partner. It now opens a small window where you enter a five digit connection code and choose your game from a drop-down list including every DS title (Diamond, Pearl, Platinum, HeartGold, SoulSilver, Black, White, Black 2 and White 2). After starting, the console displays both teams, applies the soul link fainting rule, and logs updates to `soul_link_log.json`.
-* `launch_tracker.py` – Tkinter GUI that lets you select a DS game, writes the choice to `config.txt`, and launches DeSmuME with `team_export.lua`.
+* `launch_tracker.py` – Tkinter GUI that scans the `Roms` folder for DS ROMs, lets you select one, writes the name to `config.txt`, and launches DeSmuME with `team_export.lua` while hiding the console on Windows.
 
 Run `team_export.lua` through DeSmuME's Lua scripting interface and execute `soul_link.py` while playing to sync your party with your partner.
 

--- a/launch_tracker.py
+++ b/launch_tracker.py
@@ -1,22 +1,42 @@
 #!/usr/bin/env python3
-"""Simple GUI to select a Pokémon game and launch DeSmuME."""
+"""GUI utility to select a ROM and launch DeSmuME with nicer visuals."""
 
+from __future__ import annotations
+
+import ctypes
 import os
 import subprocess
 import tkinter as tk
 from tkinter import ttk, messagebox
 
-GAMES = [
-    "Black/White",
-    "Black2/White2",
-    "Diamond/Pearl",
-    "HeartGold/SoulSilver",
-]
+
+def available_roms(rom_dir: str) -> dict[str, str]:
+    """Return mapping of display names to ROM file paths."""
+    try:
+        files = [
+            f
+            for f in os.listdir(rom_dir)
+            if os.path.isfile(os.path.join(rom_dir, f))
+        ]
+    except OSError:
+        return {}
+
+    roms: dict[str, str] = {}
+    for file in files:
+        name, _ = os.path.splitext(file)
+        display = name.replace("_", " ")
+        roms[display] = os.path.join(rom_dir, file)
+    return roms
 
 
 def launch_tracker() -> None:
-    """Write game selection to config.txt and launch DeSmuME."""
+    """Write selection to config.txt and launch DeSmuME with ROM."""
     game = game_var.get()
+    rom_path = ROMS.get(game)
+    if not rom_path:
+        messagebox.showerror("Error", "Selected ROM not found.")
+        return
+
     config_path = os.path.join(BASE_DIR, "config.txt")
     try:
         with open(config_path, "w", encoding="utf-8") as cfg:
@@ -28,8 +48,16 @@ def launch_tracker() -> None:
     desmume = os.path.join(BASE_DIR, "desmume.exe")
     lua_script = os.path.join(BASE_DIR, "team_export.lua")
 
+    creationflags = 0
+    if os.name == "nt":
+        creationflags = subprocess.CREATE_NO_WINDOW
+
     try:
-        subprocess.Popen([desmume, f"--lua={lua_script}"], cwd=BASE_DIR)
+        subprocess.Popen(
+            [desmume, rom_path, f"--lua={lua_script}"],
+            cwd=BASE_DIR,
+            creationflags=creationflags,
+        )
     except OSError as exc:
         messagebox.showerror("Error", f"Failed to launch DeSmuME: {exc}")
         return
@@ -38,19 +66,44 @@ def launch_tracker() -> None:
 
 if __name__ == "__main__":
     BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+    ROM_DIR = os.path.join(BASE_DIR, "Roms")
+    ROMS = available_roms(ROM_DIR)
+
+    if os.name == "nt":  # best effort to hide console window
+        try:
+            ctypes.windll.user32.ShowWindow(
+                ctypes.windll.kernel32.GetConsoleWindow(), 0
+            )
+        except Exception:  # pragma: no cover - shouldn't fail hard
+            pass
 
     root = tk.Tk()
     root.title("Pokémon Game Selector")
+    root.resizable(False, False)
 
-    ttk.Label(root, text="Select a Pokémon game:").pack(padx=10, pady=10)
+    style = ttk.Style()
+    try:
+        style.theme_use("clam")
+    except tk.TclError:  # pragma: no cover
+        pass
+    style.configure("TLabel", font=("Segoe UI", 11))
+    style.configure("TButton", font=("Segoe UI", 10))
 
-    game_var = tk.StringVar(value=GAMES[0])
-    ttk.Combobox(
-        root, textvariable=game_var, values=GAMES, state="readonly"
-    ).pack(padx=10, pady=10)
+    frame = ttk.Frame(root, padding=20)
+    frame.pack()
 
-    ttk.Button(root, text="Launch Tracker", command=launch_tracker).pack(
-        padx=10, pady=10
+    ttk.Label(frame, text="Select a Pokémon ROM:").grid(row=0, column=0, pady=(0, 10))
+
+    game_var = tk.StringVar()
+    game_combo = ttk.Combobox(
+        frame, textvariable=game_var, values=sorted(ROMS.keys()), state="readonly"
+    )
+    game_combo.grid(row=1, column=0, pady=(0, 10))
+    if ROMS:
+        game_var.set(sorted(ROMS.keys())[0])
+
+    ttk.Button(frame, text="Launch Tracker", command=launch_tracker).grid(
+        row=2, column=0, pady=(0, 10)
     )
 
     root.mainloop()


### PR DESCRIPTION
## Summary
- Detect ROMs in the `Roms` folder and populate the launcher menu automatically
- Refine launcher's visuals with themed widgets and a fixed-size layout
- Hide Windows consoles and launch DeSmuME with the selected ROM

## Testing
- `python -m py_compile launch_tracker.py`


------
https://chatgpt.com/codex/tasks/task_e_688d050f8b808325b64c3a73ed520377